### PR TITLE
Fix huge negative numbers on challenges

### DIFF
--- a/borderlands/savefile.py
+++ b/borderlands/savefile.py
@@ -1609,6 +1609,19 @@ class App(object):
             # Re-wrap the data
             player[15][0][1] = self.wrap_challenges(data)
 
+        if config.fix_challenge_overflow:
+            data = self.unwrap_challenges(player[15][0][1])
+
+            # Loop through
+            for save_challenge in data['challenges']:
+                if save_challenge['id'] in self.challenges:
+                    if save_challenge['total_value'] >= 2000000000:
+                        print(f'fix overflow in: {save_challenge["_name"]}')
+                        save_challenge['total_value'] = self.challenges[save_challenge['id']].get_max() + 1
+
+            # Re-wrap the data
+            player[15][0][1] = self.wrap_challenges(data)
+
         if config.name is not None and len(config.name) > 0:
             self.debug(' - Setting character name to "%s"' % (config.name))
             data = self.apply_structure(self.read_protobuf(player[19][0][1]), save_structure[19][2])
@@ -1861,6 +1874,11 @@ class App(object):
         parser.add_argument('--maxammo',
                 action='store_true',
                 help='Fill all ammo pools to their maximum',
+                )
+
+        parser.add_argument('--fix-challenge-overflow',
+                action='store_true',
+                help='Fix values for challenges that look as huge negative numbers',
                 )
 
         # Positional args


### PR DESCRIPTION
**Note:** I know about `--challenges max` but prefer fair play :)

New command line option for fixing only challenges that got overflow.

**Links to source problem**
https://steamcommunity.com/app/49520/discussions/0/1327844097129063344/ 
https://steamcommunity.com/app/49520/discussions/0/38596748231645372/

**How to use**
```
$ bl2_save_edit.py -o savegame --fix-challenge-overflow Save0001.sav Save0001_fixed.sav

Opening Save0001.sav for input file

Performing requested changes
fix overflow in: Dolla Dolla Bills, Y'all
fix overflow in: Say "Watt" Again
fix overflow in: Slag-Licked
fix overflow in: Gun Slinger
fix overflow in: Heal Plz

Opening Save0001_fixed.sav for output file
Writing savegame file

Done!
```